### PR TITLE
Ensure that 'unicodes' is a list

### DIFF
--- a/Lib/extractor/formats/opentype.py
+++ b/Lib/extractor/formats/opentype.py
@@ -561,7 +561,7 @@ def extractOpenTypeGlyphs(source, destination):
                 xMin, yMin, xMax, yMax = bounds_pen.bounds
                 destinationGlyph.verticalOrigin = tsb + yMax
         # unicodes
-        destinationGlyph.unicodes = sorted(reversedMapping.get(glyphName, []))
+        destinationGlyph.unicodes = list(reversedMapping.get(glyphName, []))
 
 
 # -------

--- a/Lib/extractor/formats/opentype.py
+++ b/Lib/extractor/formats/opentype.py
@@ -561,7 +561,7 @@ def extractOpenTypeGlyphs(source, destination):
                 xMin, yMin, xMax, yMax = bounds_pen.bounds
                 destinationGlyph.verticalOrigin = tsb + yMax
         # unicodes
-        destinationGlyph.unicodes = reversedMapping.get(glyphName, [])
+        destinationGlyph.unicodes = sorted(reversedMapping.get(glyphName, []))
 
 
 # -------


### PR DESCRIPTION
The `Glyph.unicodes` of the latest defcon and ufoLib2 are expected to be of list type. However, `ttFont['cmap'].buildReversed()` returns a set, so we need to convert it to a list.