### PR TITLE
Fix that space glyph's unicodes could be empty

### DIFF
--- a/Lib/extractor/formats/opentype.py
+++ b/Lib/extractor/formats/opentype.py
@@ -544,6 +544,8 @@ def extractOpenTypeGlyphs(source, destination):
             sourceGlyph.draw(pen)
         # width
         destinationGlyph.width = sourceGlyph.width
+        # unicodes
+        destinationGlyph.unicodes = list(reversedMapping.get(glyphName, []))
         # height and vertical origin
         if vmtx is not None and glyphName in vmtx.metrics:
             destinationGlyph.height = vmtx[glyphName][0]
@@ -560,8 +562,6 @@ def extractOpenTypeGlyphs(source, destination):
                     continue
                 xMin, yMin, xMax, yMax = bounds_pen.bounds
                 destinationGlyph.verticalOrigin = tsb + yMax
-        # unicodes
-        destinationGlyph.unicodes = list(reversedMapping.get(glyphName, []))
 
 
 # -------


### PR DESCRIPTION
Applying `extractUFO` to a TTF with vmtx, such as a CJK font, may result in an empty list of unicodes for the space glyph.
According to the OpenType specification, VORG is a CFF OpenType specific table, so the path for measuring the bounding box using `ControlBoundsPen` will be performed in `extractOpenTypeGlyphs`. In the case of the space glyph, the bounding box is `None`, so we have to `continue` before setting the unicodes. However, this does not seem to be the correct behavior.

To reproduce the problem you can use for example the following font:
https://github.com/fontworks-fonts/Reggae/blob/master/fonts/ttf/ReggaeOne-Regular.ttf