### PR TITLE
Type1 macroman

### DIFF
--- a/Lib/extractor/formats/type1.py
+++ b/Lib/extractor/formats/type1.py
@@ -28,12 +28,7 @@ def extractFontFromType1(
     doKerning=True,
     customFunctions=[],
 ):
-    try:
-        source = T1Font(pathOrFile, encoding="ascii")
-        source["FontInfo"]
-    except UnicodeDecodeError:
-        source = T1Font(pathOrFile, encoding="macroman")
-
+    source = T1Font(pathOrFile, encoding="macroman")
     destination.lib["public.glyphOrder"] = _extractType1GlyphOrder(source)
     if doInfo:
         extractType1Info(source, destination)

--- a/Lib/extractor/formats/type1.py
+++ b/Lib/extractor/formats/type1.py
@@ -29,12 +29,10 @@ def extractFontFromType1(
     customFunctions=[],
 ):
     try:
-        encoding = "ascii"
-        source = T1Font(pathOrFile, encoding=encoding)
+        source = T1Font(pathOrFile, encoding="ascii")
         source["FontInfo"]
     except UnicodeDecodeError:
-        encoding = "macroman"
-        source = T1Font(pathOrFile, encoding=encoding)
+        source = T1Font(pathOrFile, encoding="macroman")
 
     destination.lib["public.glyphOrder"] = _extractType1GlyphOrder(source)
     if doInfo:


### PR DESCRIPTION
Improve by trying to read ascii, if that fails read the fontfile with macroman encoding.

Fontographer had macroman as default.

+ simplify glyphOrder extractor: python 3 dict keys are ordered