### PR TITLE
Add missing fontFeatures dependency, update requirements to match

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 pytest
 ufo2ft
+defcon
+ufoLib2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 fonttools
-defcon
-ufoLib2
 fontFeatures

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup_params = dict(
     ],
     install_requires=[
         "fonttools[ufo,lxml,woff,unicode,type1]>=4.17.0",
+        "fontFeatures",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Extracting from a OTF will not work without the fontFeatures dependency. Additionally, the requirements.txt had dependencies which are only used in tests.