### PR TITLE
Better fallback for kerning info extraction

### DIFF
--- a/Lib/extractor/formats/opentype.py
+++ b/Lib/extractor/formats/opentype.py
@@ -578,7 +578,7 @@ def extractOpenTypeKerning(source, destination):
     groups = {}
     if "GPOS" in source:
         kerning, groups = _extractOpenTypeKerningFromGPOS(source)
-    elif "kern" in source:
+    if kerning == {} and "kern" in source:
         kerning = _extractOpenTypeKerningFromKern(source)
         groups = {}
     for name, group in groups.items():


### PR DESCRIPTION
"GPOS" might exist but hold no kerning-related data. This will attempt extracting kerning data from "kern" in such case.