### PR TITLE
vfbLib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Supported input formats:
    (``*.ttx``)
 -  WOFF 1.0/2.0 (``*.woff``, ``*.woff2``)
 -  PostScript Type1 fonts (``*.pfa``, ``*.pfb``, etc.)
--  FontLab files (``*.vfb``)
+-  FontLab files (``*.vfb``, when installed with optional dependency "vfb")
 
 Installation
 ------------
@@ -37,6 +37,12 @@ You can install ``extractor`` with ``pip``:
 .. code::
 
    $ pip install ufo-extractor
+
+To install with support for extracting from vfb files:
+
+.. code::
+
+   $ pip install ufo-extractor[vfb]
 
 Note that, for historical reasons, the package is listed on the
 `Python Package Index <https://travis-ci.org/typesupply/extractor>`__ under the name

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setup_params = dict(
         "fonttools[ufo,lxml,woff,unicode,type1]>=4.17.0",
         "fontFeatures",
     ],
+    extras_require={
+        "vfb": ["vfbLib>=0.7.1"],
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Use vfbLib to extract vfbs instead of vfb2ufo.

Adds an optional dependency called "vfb":

```bash
pip install ufo-extractor[vfb]
```